### PR TITLE
Fixing a double patching issue...

### DIFF
--- a/GameData/TundraTechnologies/Patches/Tweakscale.cfg
+++ b/GameData/TundraTechnologies/Patches/Tweakscale.cfg
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[TT_19_IRI_BODY,TT_19_NH_SOLAR]:NEEDS[TweakScale]
+@PART[TT_19_NH_SOLAR]:NEEDS[TweakScale]
 {
 	%MODULE[TweakScale]
 	{


### PR DESCRIPTION
... preventing it to trigger the TweakScale Sanity Check for Issue #34

This was reported on Forum: https://forum.kerbalspaceprogram.com/index.php?/topic/179030-14-tweakscale-under-lisias-management-2430-2019-0608/&do=findComment&comment=3615001

And a full description why this happens can be found on the TweakScale's issue track: https://github.com/net-lisias-ksp/TweakScale/issues/34