### PR TITLE
Fix tech required typo

### DIFF
--- a/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_Forward_FIN_L.cfg
+++ b/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_Forward_FIN_L.cfg
@@ -10,7 +10,7 @@
 	CoMOffset = -0.0, 0.0, 0.4
 	CoLOffset = -1.053, -0.712, 0
 	
-	TechRequired = advMetalWorks
+	TechRequired = advMetalworks
 	entryCost = 1200
 	cost = 1200
 	category = Aero

--- a/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_Forward_FIN_R.cfg
+++ b/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_Forward_FIN_R.cfg
@@ -10,7 +10,7 @@
 	CoMOffset = -0.0, 0.0, 0.4
 	CoLOffset = -1.053, -0.712, 0
 	
-	TechRequired = advMetalWorks
+	TechRequired = advMetalworks
 	entryCost = 1200
 	cost = 1200
 	category = Aero

--- a/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL.cfg
+++ b/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL.cfg
@@ -16,7 +16,7 @@
 	CoMOffset = 0.0, -1.81, 1.421
 	CoLOffset = 0.0, -1.4, 0
 	
-	TechRequired = advMetalWorks
+	TechRequired = advMetalworks
 	entryCost = 1500
 	cost = 1200
 	category = Aero

--- a/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL_WING_L.cfg
+++ b/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL_WING_L.cfg
@@ -10,7 +10,7 @@
 	CoMOffset = 0.0, -1.81, 1.421
 	CoLOffset = 0.0, -1.4, 0
 	
-	TechRequired = advMetalWorks
+	TechRequired = advMetalworks
 	entryCost = 1500
 	cost = 1200
 	category = Aero

--- a/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL_WING_R.cfg
+++ b/GameData/TundraExploration/Parts/GOJIRAII/TE_18_BFS_TAIL_WING_R.cfg
@@ -10,7 +10,7 @@
 	CoMOffset = 0.0, -1.81, 1.421
 	CoLOffset = 0.0, -1.4, 0
 	
-	TechRequired = advMetalWorks
+	TechRequired = advMetalworks
 	entryCost = 1500
 	cost = 1200
 	category = Aero


### PR DESCRIPTION
I fixed the TechRequired typo, which now allows the parts to be accessible in science and career mode. This fixes [Issue #17 ](https://github.com/damonvv/TundraExploration/issues/17).