### PR TITLE
Move Falcon 1 fairing side to Basic Rocketry

### DIFF
--- a/GameData/TundraExploration/Parts/Falcon1/TE_21_F1_Fairing_Half.cfg
+++ b/GameData/TundraExploration/Parts/Falcon1/TE_21_F1_Fairing_Half.cfg
@@ -20,7 +20,7 @@ PART
 	
 	CoMOffset = 0.0, 0.7, 0.0
 	
-	TechRequired = generalRocketry
+	TechRequired = basicRocketry
 	entryCost = 3000
 	cost = 600
 	category = Payload


### PR DESCRIPTION
Every other Falcon 1 part is in Basic Rocketry, but the fairing side has been sitting one node higher in General Rocketry. Giving the entire Falcon 1 stack a consistent location in the tech tree will make the rocket easier to use as soon as it's unlocked.